### PR TITLE
Update STOCH.js

### DIFF
--- a/indicators/STOCH.js
+++ b/indicators/STOCH.js
@@ -70,8 +70,7 @@ Indicator.prototype.update = function(candle) {
     var LL = this.getLowest();
     var HH = this.getHighest()
 
-    
-
+   
 
     var K = candle.close - LL;
     K = K / (HH - LL) * 100;

--- a/indicators/STOCH.js
+++ b/indicators/STOCH.js
@@ -1,7 +1,9 @@
 // Stochastic Oscillator Slow - STOCH
 // Ported by Gab0 march-2018
 // ref http://www.tadoc.org/indicator/STOCH.htm
-// state: badly coded, uncertain results;
+// Added Smooth K, set to 1 to disable
+// Takes 5-6 candles for K % D calculations to catch up initially??
+// Added - if (candle.high !== candle.low), to stop NaN values in K&D when no exchange data
 
 var SMA = require('./SMA');
 var _ = require('lodash');
@@ -18,6 +20,8 @@ var Indicator = function(settings) {
     this.KPeriods = settings.KPeriods;
 
     this.KMA = new SMA(settings.DPeriods);
+    this.smoothK = new SMA(settings.smoothKPeriods);
+
 }
 
 Indicator.prototype.getLowest = function()
@@ -55,6 +59,9 @@ Indicator.prototype.getHighest = function()
 
 Indicator.prototype.update = function(candle) {
 
+    if (candle.high !== candle.low)
+    {
+
     this.candles.push(candle);
     if (this.candles.length > this.KPeriods)
         this.candles.shift();
@@ -63,14 +70,20 @@ Indicator.prototype.update = function(candle) {
     var LL = this.getLowest();
     var HH = this.getHighest()
 
+    
+
 
     var K = candle.close - LL;
     K = K / (HH - LL) * 100;
 
-    this.KMA.update(K);
+    this.smoothK.update(K)
 
-    this.K = K;
+    var smoothD = this.smoothK.result
+    this.KMA.update(smoothD);
+
+    this.K = this.smoothK.result;
     this.D = this.KMA.result;
+    }
 }
 
 module.exports = Indicator;

--- a/indicators/STOCH.js
+++ b/indicators/STOCH.js
@@ -70,7 +70,7 @@ Indicator.prototype.update = function(candle) {
     var LL = this.getLowest();
     var HH = this.getHighest()
 
-   
+  
 
     var K = candle.close - LL;
     K = K / (HH - LL) * 100;


### PR DESCRIPTION
Getting the same values as Tradingview.
Make sure the time zone is correct on tradingview to compare. 
When the exchange  data fails Tradingview cut out the data that is missing but gekko just freezes and all the numbers go to the same for close, high and low candle. Then causes the K and D numbers to NaN, stopped this with - if (candle.high !== candle.low).
Added Smooth K, set to 1 to disable
Takes 5-6 candles for K % D calculations to catch up initially ?? not sure how to correct this

Test with:

var method = {};

method.init = function() {

    this.name = "Tradingview-tester";

    this.addIndicator('ind', 'STOCH', {KPeriods: 5, DPeriods: 3, smoothKPeriods :2});

};

method.check = function() {};
method.update= function(candle) {

    console.log("Time: " + candle.start.format())
    console.log("High : " + candle.high);
    console.log("Low : " + candle.low);
    console.log("Close : " + candle.close);
    console.log("LL : " + this.indicators.ind.getLowest());
    console.log("HH : " + this.indicators.ind.getHighest());
    console.log("%K: " + this.indicators.ind.K);
    console.log("%D: " + this.indicators.ind.D);
    console.log();
};
method.log = function() {};

module.exports = method;